### PR TITLE
item_ui component

### DIFF
--- a/custom_resources/control_ui_base.gd
+++ b/custom_resources/control_ui_base.gd
@@ -1,0 +1,46 @@
+extends Control
+class_name ControlUiBase
+
+const BASE_STYLEBOX := preload("res://scenes/item_ui/item_base_stylebox.tres")
+const DRAG_STYLEBOX := preload("res://scenes/item_ui/item_dragging_stylebox.tres")
+const HOVER_STYLEBOX := preload("res://scenes/item_ui/item_hover_stylebox.tres")
+
+@export var item: Resource:
+	set = _set_item
+@onready var panel: Panel = $Panel
+@onready var cost: Label = $Cost
+@onready var icon: TextureRect = $Icon
+
+var parent: Control
+
+var state_machine
+var child
+
+func init(props):
+	self.state_machine = props.state_machine
+	self.child = props.child
+	state_machine.init(child)
+
+func _input(event: InputEvent) -> void:
+	self.state_machine.on_input(event)
+
+
+func _on_gui_input(event: InputEvent) -> void:
+	self.state_machine.on_gui_input(event)
+
+
+func _on_mouse_entered() -> void:
+	self.state_machine.on_mouse_entered()
+
+
+func _on_mouse_exited() -> void:
+	self.state_machine.on_mouse_exited()
+
+
+func _set_item(value: Resource) -> void:
+	if not is_node_ready():
+		await ready
+
+	item = value
+	cost.text = str(item.cost)
+	icon.texture = item.icon

--- a/global/events.gd
+++ b/global/events.gd
@@ -6,8 +6,9 @@ signal card_drag_ended(card_iu: CardUI)
 signal card_aim_started(card_ui: CardUI)
 signal card_aim_ended(card_ui: CardUI)
 signal card_played(card: Card)
-signal card_tooltip_requested(card: Card)
+signal tooltip_requested(icon: Texture, text: String)
 signal card_selected(card_ui: CardUI)
+signal item_selected(item_ui: ItemUI)
 signal tooltip_hide_requested
 
 #Player-related events

--- a/scenes/battle/battle.gd
+++ b/scenes/battle/battle.gd
@@ -31,7 +31,7 @@ func _ready() -> void:
 
 func start_battle(stats: CharacterStats) -> void:
 	get_tree().paused = false
-	MusicPlayer.play(music, true)	
+	# MusicPlayer.play(music, true)	
 	battle_ui._on_wave_level_changed(current_wave_level)
 	scenario_handler.spawn_wave(battle_scenario, current_wave_level)
 	enemy_handler.reset_enemy_actions()

--- a/scenes/battle/battle.gd
+++ b/scenes/battle/battle.gd
@@ -31,7 +31,7 @@ func _ready() -> void:
 
 func start_battle(stats: CharacterStats) -> void:
 	get_tree().paused = false
-	# MusicPlayer.play(music, true)	
+	MusicPlayer.play(music, true)	
 	battle_ui._on_wave_level_changed(current_wave_level)
 	scenario_handler.spawn_wave(battle_scenario, current_wave_level)
 	enemy_handler.reset_enemy_actions()

--- a/scenes/battle/deck_info_panel.gd
+++ b/scenes/battle/deck_info_panel.gd
@@ -3,7 +3,6 @@ extends Panel
 @onready var player = %Player
 @onready var card_list_panel = %CardListPanel
 @onready var cards_quantity_label = %NumCards
-# @onready var card_ui = preload("res://scenes/card_ui/card_ui.tscn")
 @onready var item_ui = preload("res://scenes/item_ui/item_ui.tscn")
 
 var list_counter = 0
@@ -17,15 +16,12 @@ func _on_deck_info_open_button_pressed():
 	var cards_count = len(card_list.cards)
 	cards_quantity_label.text = "There are %s cards in deck" % cards_count
 	print("quantity", cards_count)
-	# var stats = player.stats
 	for card in card_list.cards:
 		if list_counter < cards_count:
 			var item_ui_instance := item_ui.instantiate()
 			card_list_panel.add_child(item_ui_instance)
-			# item_ui_instance.character_stats = stats
 			item_ui_instance.item = card
 			item_ui_instance.parent = self
-			# item_ui_instance.preview_mode = true
 			item_ui_instance.disabled = true
 			item_ui_instance.global_position += card_list_panel.global_position + Vector2(10, 10)
 			item_ui_instance.selectable = false

--- a/scenes/battle/deck_info_panel.gd
+++ b/scenes/battle/deck_info_panel.gd
@@ -3,10 +3,10 @@ extends Panel
 @onready var player = %Player
 @onready var card_list_panel = %CardListPanel
 @onready var cards_quantity_label = %NumCards
-@onready var card_ui = preload("res://scenes/card_ui/card_ui.tscn")
+# @onready var card_ui = preload("res://scenes/card_ui/card_ui.tscn")
+@onready var item_ui = preload("res://scenes/item_ui/item_ui.tscn")
 
 var list_counter = 0
-
 
 func _ready():
 	self.hide()
@@ -17,17 +17,17 @@ func _on_deck_info_open_button_pressed():
 	var cards_count = len(card_list.cards)
 	cards_quantity_label.text = "There are %s cards in deck" % cards_count
 	print("quantity", cards_count)
-	var stats = player.stats
+	# var stats = player.stats
 	for card in card_list.cards:
 		if list_counter < cards_count:
-			var new_card_ui := card_ui.instantiate()
-			card_list_panel.add_child(new_card_ui)
-			new_card_ui.character_stats = stats
-			new_card_ui.card = card
-			new_card_ui.parent = self
-			new_card_ui.preview_mode = true
-			new_card_ui.disabled = true
-			new_card_ui.global_position += card_list_panel.global_position + Vector2(10, 10)
+			var item_ui_instance := item_ui.instantiate()
+			card_list_panel.add_child(item_ui_instance)
+			# item_ui_instance.character_stats = stats
+			item_ui_instance.item = card
+			item_ui_instance.parent = self
+			# item_ui_instance.preview_mode = true
+			item_ui_instance.disabled = true
+			item_ui_instance.global_position += card_list_panel.global_position + Vector2(10, 10)
 			list_counter += 1
 
 	self.show()

--- a/scenes/battle/deck_info_panel.gd
+++ b/scenes/battle/deck_info_panel.gd
@@ -28,6 +28,7 @@ func _on_deck_info_open_button_pressed():
 			# item_ui_instance.preview_mode = true
 			item_ui_instance.disabled = true
 			item_ui_instance.global_position += card_list_panel.global_position + Vector2(10, 10)
+			item_ui_instance.selectable = false
 			list_counter += 1
 
 	self.show()

--- a/scenes/card_ui/card_states/card_base_state.gd
+++ b/scenes/card_ui/card_states/card_base_state.gd
@@ -32,7 +32,7 @@ func on_mouse_entered() -> void:
 		return
 		
 	card_ui.panel.set("theme_override_styles/panel", card_ui.HOVER_STYLEBOX)
-	Events.card_tooltip_requested.emit(card_ui.card.icon, card_ui.card.tooltip_text)
+	Events.tooltip_requested.emit(card_ui.card.icon, card_ui.card.tooltip_text)
 
 func on_mouse_exited() -> void:
 	if not card_ui.preview_mode and (not card_ui.playable or card_ui.disabled):

--- a/scenes/card_ui/card_ui.gd
+++ b/scenes/card_ui/card_ui.gd
@@ -1,30 +1,25 @@
 class_name CardUI
-extends Control
+extends ControlUiBase
 
 #A signal to reparent back to hbox container as dragged card will be out of hbox container
 signal reparent_requested(which_card_ui: CardUI)
 
-const BASE_STYLEBOX := preload("res://scenes/card_ui/card_base_stylebox.tres")
-const DRAG_STYLEBOX := preload("res://scenes/card_ui/card_dragging_stylebox.tres")
-const HOVER_STYLEBOX := preload("res://scenes/card_ui/card_hover_stylebox.tres")
-
 @export var card: Card : set = _set_card
 @export var character_stats: CharacterStats : set = _set_character_stats
 
-@onready var panel: Panel = $Panel
-@onready var cost: Label = $Cost
-@onready var icon: TextureRect = $Icon
 @onready var card_state_machine: CardStateMachine = $CardStateMachine as CardStateMachine
 @onready var drop_point_detector: Area2D = $DropPointDetector
 @onready var targets: Array[Node] = []
 @onready var original_index := self.get_index()
 
-var parent: Control
 var tween: Tween
 var playable := true : set = _set_playable
 var disabled := false
 var selectable = false
 var preview_mode = false : set = _set_preview_mode
+
+func init(props):
+	super(props)
 
 func _ready() -> void:
 	#Connect signals from event bus
@@ -32,8 +27,11 @@ func _ready() -> void:
 	Events.card_drag_started.connect(_on_card_drag_or_aiming_started)
 	Events.card_aim_ended.connect(_on_card_drag_or_aiming_ended)
 	Events.card_drag_ended.connect(_on_card_drag_or_aiming_ended)
-	#Initiate the state machine
-	card_state_machine.init(self)
+	var props = {
+		state_machine = card_state_machine,
+		child = self
+	}
+	self.init(props)
 
 
 func animate_to_position(new_position: Vector2, duration: float) -> void:
@@ -48,27 +46,9 @@ func play() -> void:
 	card.play(targets, character_stats)
 	queue_free()
 
-func _input(event: InputEvent) -> void:
-	card_state_machine.on_input(event)
-
-func _on_gui_input(event: InputEvent) -> void:
-	card_state_machine.on_gui_input(event)
-
-func _on_mouse_entered() -> void:
-	card_state_machine.on_mouse_entered()
-
-func _on_mouse_exited() -> void:
-	card_state_machine.on_mouse_exited()
-
-
 func _set_card(value: Card) -> void:
-	if not is_node_ready():
-		await ready
-	
-	card = value
-	cost.text = str(card.cost)
-	icon.texture = card.icon
-
+	super._set_item(value)
+	card = item
 
 func _set_playable(value: bool) -> void:
 	playable = value

--- a/scenes/item_ui/item_base_stylebox.tres
+++ b/scenes/item_ui/item_base_stylebox.tres
@@ -1,0 +1,9 @@
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://bbe36lb7haitj"]
+
+[resource]
+bg_color = Color(0.631373, 0.34902, 0.321569, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.67451, 0.67451, 0.67451, 1)

--- a/scenes/item_ui/item_dragging_stylebox.tres
+++ b/scenes/item_ui/item_dragging_stylebox.tres
@@ -1,0 +1,11 @@
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://fxfavo7o3vr4"]
+
+[resource]
+bg_color = Color(0.631373, 0.34902, 0.321569, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.780392, 0.666667, 0.294118, 1)
+shadow_color = Color(0.780392, 0.666667, 0.294118, 0.654902)
+shadow_size = 2

--- a/scenes/item_ui/item_hover_stylebox.tres
+++ b/scenes/item_ui/item_hover_stylebox.tres
@@ -1,0 +1,9 @@
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://dgm31x3u00pfl"]
+
+[resource]
+bg_color = Color(0.631373, 0.34902, 0.321569, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.780392, 0.666667, 0.294118, 1)

--- a/scenes/item_ui/item_state_machine.gd
+++ b/scenes/item_ui/item_state_machine.gd
@@ -1,0 +1,59 @@
+class_name ItemStateMachine
+extends Node
+
+@export var initial_state: ItemState
+
+var current_state: ItemState
+
+var states = {}
+
+
+func init(item: ItemUI) -> void:
+	for child in get_children():
+		if child is ItemState:
+			states[child.state] = child
+			child.transition_requested.connect(_on_transition_requested)  #connect signal from state to transition function
+			child.item_ui = item
+
+	if initial_state:
+		initial_state.enter()
+		current_state = initial_state
+
+
+func on_input(event: InputEvent) -> void:
+	if current_state:
+		current_state.on_input(event)
+
+
+func on_gui_input(event: InputEvent) -> void:
+	if current_state:
+		current_state.on_gui_input(event)
+
+
+func on_mouse_entered() -> void:
+	if current_state:
+		current_state.on_mouse_entered()
+
+
+func on_mouse_exited() -> void:
+	if current_state:
+		current_state.on_mouse_exited()
+
+
+func _on_transition_requested(from: ItemState, to: ItemState.State) -> void:
+	#check if from-state is the same as current (in case something happened)
+	if from != current_state:
+		return
+
+	var new_state: ItemState = states[to]  #Take to-state from dictionary of states
+	#If we try to transition to nonexisting state we return
+	if not new_state:
+		return
+
+	#If state exists, we first exit from current state
+	if current_state:
+		current_state.exit()
+
+	#than we enter a new state and set new state as current
+	new_state.enter()
+	current_state = new_state

--- a/scenes/item_ui/item_states/item_base_state.gd
+++ b/scenes/item_ui/item_states/item_base_state.gd
@@ -1,0 +1,35 @@
+extends ItemState
+
+
+func enter():
+	if not item_ui.is_node_ready():
+		await item_ui.ready
+
+	item_ui.panel.set("theme_override_styles/panel", item_ui.BASE_STYLEBOX)
+	Events.tooltip_hide_requested.emit()
+
+
+func on_mouse_entered() -> void:
+	# if not item_ui.preview_mode and (not item_ui.playable or item_ui.disabled):
+	# 	return
+
+	item_ui.panel.set("theme_override_styles/panel", item_ui.HOVER_STYLEBOX)
+	Events.tooltip_requested.emit(item_ui.item.icon, item_ui.item.tooltip_text)
+
+
+func on_mouse_exited() -> void:
+	# if not item_ui.preview_mode and (not item_ui.playable or item_ui.disabled):
+	# 	return
+
+	item_ui.panel.set("theme_override_styles/panel", item_ui.BASE_STYLEBOX)
+	Events.tooltip_hide_requested.emit()
+
+
+func on_gui_input(event: InputEvent) -> void:
+	if item_ui.selectable and event.is_action_pressed("left_mouse"):
+		transition_requested.emit(self, ItemState.State.SELECTED)
+		Events.item_selected.emit(item_ui)
+		print(item_ui)
+
+	if not item_ui.playable or item_ui.disabled:
+		return

--- a/scenes/item_ui/item_states/item_base_state.gd
+++ b/scenes/item_ui/item_states/item_base_state.gd
@@ -10,16 +10,12 @@ func enter():
 
 
 func on_mouse_entered() -> void:
-	# if not item_ui.preview_mode and (not item_ui.playable or item_ui.disabled):
-	# 	return
 
 	item_ui.panel.set("theme_override_styles/panel", item_ui.HOVER_STYLEBOX)
 	Events.tooltip_requested.emit(item_ui.item.icon, item_ui.item.tooltip_text)
 
 
 func on_mouse_exited() -> void:
-	# if not item_ui.preview_mode and (not item_ui.playable or item_ui.disabled):
-	# 	return
 
 	item_ui.panel.set("theme_override_styles/panel", item_ui.BASE_STYLEBOX)
 	Events.tooltip_hide_requested.emit()

--- a/scenes/item_ui/item_states/item_selected_state.gd
+++ b/scenes/item_ui/item_states/item_selected_state.gd
@@ -1,0 +1,10 @@
+extends ItemState
+
+
+func enter():
+	item_ui.panel.set("theme_override_styles/panel", item_ui.DRAG_STYLEBOX)
+
+
+func on_input(event: InputEvent) -> void:
+	if event.is_action_pressed("left_mouse"):
+		transition_requested.emit(self, ItemState.State.BASE)

--- a/scenes/item_ui/item_states/item_state.gd
+++ b/scenes/item_ui/item_states/item_state.gd
@@ -1,0 +1,35 @@
+class_name ItemState
+extends Node
+
+enum State { BASE, SELECTED }
+
+#export var to assign states in editor when crating new states
+@export var state: State
+
+var item_ui: ItemUI
+
+
+signal transition_requested(from: ItemState, to: ItemState)
+#Call back functions for mouse entering and exiting. Will be redefined inside states
+func on_mouse_entered() -> void:
+	pass
+
+
+func on_mouse_exited() -> void:
+	pass
+
+
+#Function for entering a state. Will be redefined inside states
+func enter() -> void:
+	pass
+
+
+#Function for exiting the state. Will be redefined inside states
+func exit() -> void:
+	pass
+
+func on_input(_event: InputEvent) -> void:
+	pass
+
+func on_gui_input(_event: InputEvent) -> void:
+	pass

--- a/scenes/item_ui/item_ui.gd
+++ b/scenes/item_ui/item_ui.gd
@@ -1,0 +1,52 @@
+class_name ItemUI
+extends Control
+
+
+const BASE_STYLEBOX := preload("res://scenes/item_ui/item_base_stylebox.tres")
+const DRAG_STYLEBOX := preload("res://scenes/item_ui/item_dragging_stylebox.tres")
+const HOVER_STYLEBOX := preload("res://scenes/item_ui/item_hover_stylebox.tres")
+
+
+@export var item: Resource : set = _set_item
+# @export var character_stats: CharacterStats : set = _set_character_stats
+
+@onready var panel: Panel = $Panel
+@onready var cost: Label = $Cost
+@onready var icon: TextureRect = $Icon
+# @onready var item_state_machine: ItemStateMachine = $ItemStateMachine as ItemStateMachine
+
+var disabled = false
+var selectable = true
+var parent: Control
+# func _ready() -> void:
+	#Connect signals from event bus
+	# Events.item_aim_started.connect(_on_item_drag_or_aiming_started)
+	# Events.item_drag_started.connect(_on_item_drag_or_aiming_started)
+	# Events.item_aim_ended.connect(_on_item_drag_or_aiming_ended)
+	# Events.item_drag_ended.connect(_on_item_drag_or_aiming_ended)
+	#Initiate the state machine
+	# item_state_machine.init(self)
+
+
+# func _input(event: InputEvent) -> void:
+# 	item_state_machine.on_input(event)
+
+# func _on_gui_input(event: InputEvent) -> void:
+# 	item_state_machine.on_gui_input(event)
+
+# func _on_mouse_entered() -> void:
+# 	item_state_machine.on_mouse_entered()
+
+# func _on_mouse_exited() -> void:
+# 	item_state_machine.on_mouse_exited()
+
+
+func _set_item(value: Resource) -> void:
+	if not is_node_ready():
+		await ready
+	
+	item = value
+	cost.text = str(item.cost)
+	icon.texture = item.icon
+
+	

--- a/scenes/item_ui/item_ui.gd
+++ b/scenes/item_ui/item_ui.gd
@@ -7,6 +7,8 @@ const DRAG_STYLEBOX := preload("res://scenes/item_ui/item_dragging_stylebox.tres
 const HOVER_STYLEBOX := preload("res://scenes/item_ui/item_hover_stylebox.tres")
 
 
+@onready var item_state_machine: ItemStateMachine = $ItemStateMachine as ItemStateMachine
+
 @export var item: Resource : set = _set_item
 # @export var character_stats: CharacterStats : set = _set_character_stats
 
@@ -16,29 +18,24 @@ const HOVER_STYLEBOX := preload("res://scenes/item_ui/item_hover_stylebox.tres")
 # @onready var item_state_machine: ItemStateMachine = $ItemStateMachine as ItemStateMachine
 
 var disabled = false
+var playable = false
 var selectable = true
 var parent: Control
-# func _ready() -> void:
-	#Connect signals from event bus
-	# Events.item_aim_started.connect(_on_item_drag_or_aiming_started)
-	# Events.item_drag_started.connect(_on_item_drag_or_aiming_started)
-	# Events.item_aim_ended.connect(_on_item_drag_or_aiming_ended)
-	# Events.item_drag_ended.connect(_on_item_drag_or_aiming_ended)
-	#Initiate the state machine
-	# item_state_machine.init(self)
+func _ready() -> void:
+	item_state_machine.init(self)
 
 
-# func _input(event: InputEvent) -> void:
-# 	item_state_machine.on_input(event)
+func _input(event: InputEvent) -> void:
+	item_state_machine.on_input(event)
 
-# func _on_gui_input(event: InputEvent) -> void:
-# 	item_state_machine.on_gui_input(event)
+func _on_gui_input(event: InputEvent) -> void:
+	item_state_machine.on_gui_input(event)
 
-# func _on_mouse_entered() -> void:
-# 	item_state_machine.on_mouse_entered()
+func _on_mouse_entered() -> void:
+	item_state_machine.on_mouse_entered()
 
-# func _on_mouse_exited() -> void:
-# 	item_state_machine.on_mouse_exited()
+func _on_mouse_exited() -> void:
+	item_state_machine.on_mouse_exited()
 
 
 func _set_item(value: Resource) -> void:

--- a/scenes/item_ui/item_ui.gd
+++ b/scenes/item_ui/item_ui.gd
@@ -1,49 +1,18 @@
 class_name ItemUI
-extends Control
-
-
-const BASE_STYLEBOX := preload("res://scenes/item_ui/item_base_stylebox.tres")
-const DRAG_STYLEBOX := preload("res://scenes/item_ui/item_dragging_stylebox.tres")
-const HOVER_STYLEBOX := preload("res://scenes/item_ui/item_hover_stylebox.tres")
-
+extends ControlUiBase
 
 @onready var item_state_machine: ItemStateMachine = $ItemStateMachine as ItemStateMachine
-
-@export var item: Resource : set = _set_item
-# @export var character_stats: CharacterStats : set = _set_character_stats
-
-@onready var panel: Panel = $Panel
-@onready var cost: Label = $Cost
-@onready var icon: TextureRect = $Icon
-# @onready var item_state_machine: ItemStateMachine = $ItemStateMachine as ItemStateMachine
 
 var disabled = false
 var playable = false
 var selectable = true
-var parent: Control
+
+func init(props):
+	super(props)
+
 func _ready() -> void:
-	item_state_machine.init(self)
-
-
-func _input(event: InputEvent) -> void:
-	item_state_machine.on_input(event)
-
-func _on_gui_input(event: InputEvent) -> void:
-	item_state_machine.on_gui_input(event)
-
-func _on_mouse_entered() -> void:
-	item_state_machine.on_mouse_entered()
-
-func _on_mouse_exited() -> void:
-	item_state_machine.on_mouse_exited()
-
-
-func _set_item(value: Resource) -> void:
-	if not is_node_ready():
-		await ready
-	
-	item = value
-	cost.text = str(item.cost)
-	icon.texture = item.icon
-
-	
+	var props = {
+		state_machine = item_state_machine,
+		child = self
+	}
+	self.init(props)

--- a/scenes/item_ui/item_ui.tscn
+++ b/scenes/item_ui/item_ui.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=5 format=3 uid="uid://csknw816l4p70"]
+
+[ext_resource type="Theme" uid="uid://ci1edh073cu36" path="res://main_theme.tres" id="1_f6jq3"]
+[ext_resource type="Script" path="res://scenes/item_ui/item_ui.gd" id="2_w0axb"]
+[ext_resource type="StyleBox" uid="uid://byr56nx5cfdbp" path="res://scenes/card_ui/card_base_stylebox.tres" id="3_qn4gu"]
+[ext_resource type="Texture2D" uid="uid://c6rme2o6dyaoj" path="res://art/tile_0104.png" id="4_bp6wm"]
+
+[node name="ItemUI" type="Control"]
+custom_minimum_size = Vector2(25, 30)
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = -231.0
+offset_bottom = -114.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_f6jq3")
+script = ExtResource("2_w0axb")
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme_override_styles/panel = ExtResource("3_qn4gu")
+
+[node name="Cost" type="Label" parent="."]
+layout_mode = 0
+offset_right = 10.0
+offset_bottom = 10.0
+text = "9"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Icon" type="TextureRect" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -5.0
+offset_top = -5.0
+offset_right = 5.0
+offset_bottom = 5.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+texture = ExtResource("4_bp6wm")
+expand_mode = 1
+stretch_mode = 5

--- a/scenes/item_ui/item_ui.tscn
+++ b/scenes/item_ui/item_ui.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=5 format=3 uid="uid://csknw816l4p70"]
+[gd_scene load_steps=8 format=3 uid="uid://csknw816l4p70"]
 
 [ext_resource type="Theme" uid="uid://ci1edh073cu36" path="res://main_theme.tres" id="1_f6jq3"]
 [ext_resource type="Script" path="res://scenes/item_ui/item_ui.gd" id="2_w0axb"]
 [ext_resource type="StyleBox" uid="uid://byr56nx5cfdbp" path="res://scenes/card_ui/card_base_stylebox.tres" id="3_qn4gu"]
 [ext_resource type="Texture2D" uid="uid://c6rme2o6dyaoj" path="res://art/tile_0104.png" id="4_bp6wm"]
+[ext_resource type="Script" path="res://scenes/item_ui/item_state_machine.gd" id="5_sc1ko"]
+[ext_resource type="Script" path="res://scenes/item_ui/item_states/item_base_state.gd" id="6_wgml4"]
+[ext_resource type="Script" path="res://scenes/item_ui/item_states/item_selected_state.gd" id="7_itwp2"]
 
 [node name="ItemUI" type="Control"]
 custom_minimum_size = Vector2(25, 30)
@@ -53,3 +56,18 @@ mouse_filter = 2
 texture = ExtResource("4_bp6wm")
 expand_mode = 1
 stretch_mode = 5
+
+[node name="ItemStateMachine" type="Node" parent="." node_paths=PackedStringArray("initial_state")]
+script = ExtResource("5_sc1ko")
+initial_state = NodePath("ItemBaseState")
+
+[node name="ItemBaseState" type="Node" parent="ItemStateMachine"]
+script = ExtResource("6_wgml4")
+
+[node name="ItemSelectedState" type="Node" parent="ItemStateMachine"]
+script = ExtResource("7_itwp2")
+state = 1
+
+[connection signal="gui_input" from="." to="." method="_on_gui_input"]
+[connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
+[connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]

--- a/scenes/ui/battle_reward_panel.gd
+++ b/scenes/ui/battle_reward_panel.gd
@@ -13,7 +13,7 @@ var reward_variants
 
 func _ready() -> void:
 	Events.enemy_wave_cleaned.connect(show_reward_screen)
-	Events.card_selected.connect(_on_card_selection)
+	Events.item_selected.connect(_on_item_selection)
 	continue_button.disabled = true
 	if not reward_manager.is_node_ready():
 		await reward_manager.ready
@@ -25,7 +25,7 @@ func show_reward_screen(player) -> void:
 	current_player = player
 	show()
 	get_tree().paused = true
-	choose_item_panel.render(reward_variants, player.stats)
+	choose_item_panel.render(reward_variants)
 
 
 func _on_continue_button_pressed() -> void:
@@ -35,6 +35,6 @@ func _on_continue_button_pressed() -> void:
 	Events.enemy_wave_started.emit()
 
 
-func _on_card_selection(card_ui):
+func _on_item_selection(item_ui):
 	continue_button.disabled = false
-	selected_reward = card_ui.card
+	selected_reward = item_ui.item

--- a/scenes/ui/battle_reward_panel.gd
+++ b/scenes/ui/battle_reward_panel.gd
@@ -17,11 +17,11 @@ func _ready() -> void:
 	continue_button.disabled = true
 	if not reward_manager.is_node_ready():
 		await reward_manager.ready
-	reward_manager.calculate_wave_reward()
-	reward_variants = reward_manager.current_reward
 
 
 func show_reward_screen(player) -> void:
+	reward_manager.calculate_wave_reward()
+	reward_variants = reward_manager.current_reward
 	current_player = player
 	show()
 	get_tree().paused = true
@@ -30,7 +30,9 @@ func show_reward_screen(player) -> void:
 
 func _on_continue_button_pressed() -> void:
 	current_player.current_deck.add_card(selected_reward)
+	selected_reward = null
 	hide()
+	continue_button.disabled = true
 	get_tree().paused = false
 	Events.enemy_wave_started.emit()
 

--- a/scenes/ui/choose_item_panel.gd
+++ b/scenes/ui/choose_item_panel.gd
@@ -2,7 +2,6 @@ class_name ChooseItemPanel
 extends GridContainer
 
 var list_counter = 0
-# @onready var card_ui = preload("res://scenes/card_ui/card_ui.tscn")
 
 @onready var item_ui = preload("res://scenes/item_ui/item_ui.tscn")
 
@@ -14,10 +13,8 @@ func render(
 		for card in card_list.cards:
 			var item_ui_instance := item_ui.instantiate()
 			self.add_child(item_ui_instance)
-			# item_ui_instance.character_stats = stats
 			item_ui_instance.item = card
 			item_ui_instance.parent = self
-			# item_ui_instance.preview_mode = true
 			item_ui_instance.disabled = true
 			item_ui_instance.selectable = true
 			list_counter += 1

--- a/scenes/ui/choose_item_panel.gd
+++ b/scenes/ui/choose_item_panel.gd
@@ -2,18 +2,22 @@ class_name ChooseItemPanel
 extends GridContainer
 
 var list_counter = 0
-@onready var card_ui = preload("res://scenes/card_ui/card_ui.tscn")
+# @onready var card_ui = preload("res://scenes/card_ui/card_ui.tscn")
+
+@onready var item_ui = preload("res://scenes/item_ui/item_ui.tscn")
 
 
-func render(card_list: CardPile, stats):
+func render(
+	card_list: CardPile,
+):
 	if list_counter < len(card_list.cards):
 		for card in card_list.cards:
-			var new_card_ui := card_ui.instantiate()
-			self.add_child(new_card_ui)
-			new_card_ui.character_stats = stats
-			new_card_ui.card = card
-			new_card_ui.parent = self
-			new_card_ui.preview_mode = true
-			new_card_ui.disabled = true
-			new_card_ui.selectable = true
+			var item_ui_instance := item_ui.instantiate()
+			self.add_child(item_ui_instance)
+			# item_ui_instance.character_stats = stats
+			item_ui_instance.item = card
+			item_ui_instance.parent = self
+			# item_ui_instance.preview_mode = true
+			item_ui_instance.disabled = true
+			item_ui_instance.selectable = true
 			list_counter += 1

--- a/scenes/ui/tooltip.gd
+++ b/scenes/ui/tooltip.gd
@@ -14,7 +14,7 @@ var is_tooltip_visible := false
 func _ready() -> void:
 	modulate = Color.TRANSPARENT
 	hide()
-	Events.card_tooltip_requested.connect(show_tooltip)
+	Events.tooltip_requested.connect(show_tooltip)
 	Events.tooltip_hide_requested.connect(hide_tooltip)
 
 func show_tooltip(icon: Texture, text: String) -> void:


### PR DESCRIPTION
дженерик компонент для рендеринга айтемов, может рендерить карту, хранит в себе инфо о карте, что позволяет прокинуть её туда, где нужна менно карта, но также подходит и для других предметов.

Во многом похож на card_ui но сильно проще. Потом можно будет инжектнуть в логику с картами и вообще от крад юай отказаться (хуй знает как это сделать в годоте)